### PR TITLE
Improving Python 2 and 3 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: python
+python:
+  - "2.6"
+  - "2.7"
+  - "3.2"
+  - "3.3"
+  - "3.4"
+  - "3.5"
+  - "3.6"
+  - "pypy"
+  - "pypy3"
+
+env:
+  - PYTHONPATH=.
+
+install: make install_deps
+
+script: make test

--- a/envelop/__init__.py
+++ b/envelop/__init__.py
@@ -18,7 +18,7 @@
 
 from __future__ import unicode_literals
 from six.moves.urllib.parse import urlparse
-from builtins import str as text
+from six import text_type
 import io
 import os
 import yaml
@@ -50,7 +50,7 @@ class FolderStorage(dict):
 
     def __setitem__(self, name, value):
         super(FolderStorage, self).__setitem__(
-            name, self._open(name, 'w').write(text(value)))
+            name, self._open(name, 'w').write(text_type(value)))
 
     def __delitem__(self, name):
         os.unlink(os.path.join(self.path, name))
@@ -93,7 +93,7 @@ class Environment(object):
         return float(self.get(name, failobj))
 
     def get_bool(self, name, failobj=None):
-        val = text(self.get(name, failobj)).lower()
+        val = text_type(self.get(name, failobj)).lower()
         try:
             return bool(int(val))
         except ValueError:

--- a/envelop/__init__.py
+++ b/envelop/__init__.py
@@ -18,6 +18,7 @@
 
 from __future__ import unicode_literals
 from six.moves.urllib.parse import urlparse
+from builtins import str as text
 import io
 import os
 import yaml
@@ -49,7 +50,7 @@ class FolderStorage(dict):
 
     def __setitem__(self, name, value):
         super(FolderStorage, self).__setitem__(
-            name, self._open(name, 'w').write(unicode(value)))
+            name, self._open(name, 'w').write(text(value)))
 
     def __delitem__(self, name):
         os.unlink(os.path.join(self.path, name))
@@ -92,7 +93,7 @@ class Environment(object):
         return float(self.get(name, failobj))
 
     def get_bool(self, name, failobj=None):
-        val = unicode(self.get(name, failobj)).lower()
+        val = text(self.get(name, failobj)).lower()
         try:
             return bool(int(val))
         except ValueError:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 -r requirements.txt
 coverage==3.6
+future>=0.16.0
 mock==1.0.1
 nose==1.3.0
 rednose==0.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-couleur==0.5.0
 misaka==1.0.2
 python-termstyle==0.1.10
 PyYAML==3.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
-misaka==1.0.2
-python-termstyle==0.1.10
-PyYAML==3.10
+future>=0.16.0
+misaka>=1.0.2
+python-termstyle>=0.1.10
+PyYAML>=3.10
+six>=1.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-future>=0.16.0
 misaka>=1.0.2
 python-termstyle>=0.1.10
 PyYAML>=3.10

--- a/tests/functional/test_main.py
+++ b/tests/functional/test_main.py
@@ -1,7 +1,10 @@
-import commands
+from future import standard_library
+standard_library.install_aliases()
+
+import subprocess
 
 # Aliasing to avoid typing and caching the dot resolution
-run = commands.getoutput
+run = subprocess.getoutput
 
 
 def test_get():


### PR DESCRIPTION
@hltbra I made some changes to make the code compatible with both Python 2 and 3, so that we can consider using this instead of milieu in pipeapp (which of course we are currently also working to make Python 2 and 3 compatible). The tests pass when running in either Python 2 and 3. Let me know any thoughts you have!